### PR TITLE
fix: only parse ambient contexts in declaration files.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@knighted/specifier",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knighted/specifier",
-      "version": "1.0.0-alpha.2",
+      "version": "1.0.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.22.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knighted/specifier",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "description": "Node tool for updating your ESM import and export specifiers.",
   "type": "module",
   "main": "dist",

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ const validateFilename = async (filename, path) => {
 }
 const getAst = (file, filename) => {
   try {
-    return parse(file)
+    return parse(file, /\.d\.[mc]?ts$/.test(filename))
   } catch (err) {
     const { code, reasonCode, loc, pos } = err
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,12 +1,12 @@
 import { parse as babelParse } from '@babel/parser'
 
-const parse = source => {
+const parse = (source, dts = false) => {
   const ast = babelParse(source, {
     sourceType: 'module',
     allowAwaitOutsideFunction: true,
     allowReturnOutsideFunction: true,
     allowImportExportEverywhere: true,
-    plugins: ['jsx', ['typescript', { dts: true }]],
+    plugins: ['jsx', ['typescript', { dts }]],
   })
 
   return ast

--- a/test/__fixtures__/exportNamedDeclaration.js
+++ b/test/__fixtures__/exportNamedDeclaration.js
@@ -1,3 +1,3 @@
-const bar = ''
+const bar = someFunc()
 export { foo } from './path/to/module.js'
 export { bar }

--- a/test/update.js
+++ b/test/update.js
@@ -11,7 +11,7 @@ const fixtures = resolve(__dirname, '__fixtures__')
 const { update } = specifier
 
 describe('update', () => {
-  it('updates specifiers in a import declarations', async () => {
+  it('updates specifiers in import declarations', async () => {
     const code = await update(join(fixtures, 'importDeclaration.js'), spec => {
       return spec.value.replace(/(.+)\.js$/, '$1.mjs')
     })


### PR DESCRIPTION
* Only parse TypeScript ambient contexts in declaration files.