### PR TITLE
refactor!: replace redundant errorContext with syntaxError.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ const code = await specifier.mapper('dist/index.js', {
 
 The order of the keys in the map object matters, the first match found will be used, so the most specific rule should be defined first. Additionally, you can substitute captured regex groups using numbered backreferences.
 
+You can also check out the [reference implementation](https://github.com/knightedcodemonkey/duel).
+
 ## `async specifier.update(filename, callback)`
 
 Updates specifiers in `filename` using the values returned from `callback`, and returns the updated file content. The callback is called for each specifier found, and the returned value is used to update the related specifier value. If the callback returns anything other than a string, the return value will be ignored and the specifier not updated.
@@ -70,8 +72,7 @@ interface UpdateError {
     error: boolean;
     msg: string;
     filename: string | undefined;
-    syntaxError: boolean;
-    errorContext: undefined | {
+    syntaxError: undefined | {
       code: string;
       reasonCode: string;
       pos: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@knighted/specifier",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knighted/specifier",
-      "version": "1.0.0-alpha.6",
+      "version": "1.0.0-alpha.7",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.22.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knighted/specifier",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "description": "Node.js tool for updating your ESM specifiers, and CJS require strings.",
   "type": "module",
   "main": "dist",

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,7 @@ const makeError = (filename, msg, ctx) => {
     msg,
     filename,
     error: true,
-    syntaxError: Boolean(ctx),
-    errorContext: ctx,
+    syntaxError: ctx,
   }
 }
 const validateFilename = async (filename, path) => {

--- a/test/__fixtures__/jsx.jsx
+++ b/test/__fixtures__/jsx.jsx
@@ -1,0 +1,18 @@
+import './path/to/side-effect.js'
+
+const Component = () => {
+  return (
+    <p>I am a component.</p>
+  )
+}
+const App = () => {
+  return (
+    <>
+      <p>I am an app using component.</p>
+      <Component />
+    </>
+  )
+}
+
+export { App }
+export { something } from './somewhere.js'

--- a/test/mapper.js
+++ b/test/mapper.js
@@ -44,7 +44,8 @@ describe('mapper', () => {
     ret = await mapper('test/__fixtures__/syntaxError.js')
 
     assert.equal(ret.error, true)
-    assert.equal(ret.syntaxError, true)
+    assert.equal(ret.syntaxError.reasonCode, 'UnterminatedString')
+    assert.ok(Number.isFinite(ret.syntaxError.pos))
 
     ret = await mapper('test/__fixtures__/mapper.js', {
       '(': './invalid-regex.js',

--- a/test/update.js
+++ b/test/update.js
@@ -80,9 +80,9 @@ describe('update', () => {
     ret = await update('test/__fixtures__/syntaxError.js')
 
     assert.equal(ret.error, true)
-    assert.ok(typeof ret.errorContext.reasonCode === 'string')
-    assert.ok(Number.isFinite(ret.errorContext.pos))
-    assert.ok(ret.errorContext.loc !== null && typeof ret.errorContext.loc === 'object')
+    assert.ok(typeof ret.syntaxError.reasonCode === 'string')
+    assert.ok(Number.isFinite(ret.syntaxError.pos))
+    assert.ok(ret.syntaxError.loc !== null && typeof ret.syntaxError.loc === 'object')
   })
 
   it('works with typescript', async () => {
@@ -98,6 +98,14 @@ describe('update', () => {
 
     assert.ok(code.indexOf('./user.mjs') > -1)
     assert.ok(code.indexOf('./other-types.js') > -1)
+  })
+
+  it('works with jsx', async () => {
+    const code = await update(join(fixtures, 'jsx.jsx'), () => {
+      return './jsx.js'
+    })
+
+    assert.equal(code.match(/\.\/jsx\.js/g).length, 2)
   })
 
   it('wraps specifier.mapper if second arg is an object', async () => {

--- a/test/updateCode.js
+++ b/test/updateCode.js
@@ -28,8 +28,8 @@ describe('updateCode', () => {
 
     assert.equal(ret.error, true)
     assert.ok(ret.msg.startsWith('Unterminated string constant'))
-    assert.ok(typeof ret.errorContext.reasonCode === 'string')
-    assert.ok(Number.isFinite(ret.errorContext.pos))
-    assert.ok(ret.errorContext.loc !== null && typeof ret.errorContext.loc === 'object')
+    assert.ok(typeof ret.syntaxError.reasonCode === 'string')
+    assert.ok(Number.isFinite(ret.syntaxError.pos))
+    assert.ok(ret.syntaxError.loc !== null && typeof ret.syntaxError.loc === 'object')
   })
 })


### PR DESCRIPTION
* Removes redundant `errorContext` in favor of using `syntaxError` for that object.
* Adds a test for JSX.
* Updates the README.